### PR TITLE
Make group more predictibles

### DIFF
--- a/demo.vite.config.js
+++ b/demo.vite.config.js
@@ -1,9 +1,6 @@
 export default {
-  root: 'demo/',
+  root: "demo/",
   build: {
-    outDir: '../dist'
-  //   rollupOptions: {
-  //     input: 'demo/main.ts',
-  //   },
+    outDir: "../dist",
   },
-}
+};

--- a/src/barchart.ts
+++ b/src/barchart.ts
@@ -254,10 +254,12 @@ export class Barchart extends Chart {
       return;
     }
     // prevent from too much movement on zoom out
+    const currentBarsCount =
+      this.currentEdgeData.items.length + this.currentNodeData.items.length;
     if (
       scale > this.currentScale &&
-      this.currentEdgeData.items.length + this.currentNodeData.items.length <
-        5 &&
+      currentBarsCount < 5 &&
+      currentBarsCount > 0 &&
       this.nodeItemsByScale[scale].items.length +
         this.nodeItemsByScale[scale].items.length <
         5

--- a/src/barchart.ts
+++ b/src/barchart.ts
@@ -189,7 +189,7 @@ export class Barchart extends Chart {
     const isLine = this.options.graph2dOptions.style === "line";
     const { nodes, edges } = (
       this.rects
-        .map((rect, i) => {
+        .map((rect) => {
           const groupX = +(rect.getAttribute("x") as string) + offsetX;
           const groupH = +(rect.getAttribute("height") as string);
           const groupY = +(rect.getAttribute("y") as string) + offsetY;
@@ -256,7 +256,8 @@ export class Barchart extends Chart {
     // prevent from too much movement on zoom out
     if (
       scale > this.currentScale &&
-      this.currentEdgeData.items.length + this.currentNodeData.items.length < 5 &&
+      this.currentEdgeData.items.length + this.currentNodeData.items.length <
+        5 &&
       this.nodeItemsByScale[scale].items.length +
         this.nodeItemsByScale[scale].items.length <
         5
@@ -345,7 +346,7 @@ export class Barchart extends Chart {
     return scales
       .slice()
       .reverse()
-      .reduce((itemsByScale, { millis, round, name }, i, scales) => {
+      .reduce((itemsByScale, { millis, round }, i, scales) => {
         // if we reached a zoom where there are not too many events,
         // just display timeline
         const gpPrev = i > 0 ? itemsByScale[scales[i - 1].millis] : undefined;

--- a/src/barchart.ts
+++ b/src/barchart.ts
@@ -1,5 +1,4 @@
 import Ogma, {
-  Edge,
   EdgeId,
   EdgeList,
   Item,
@@ -15,14 +14,7 @@ import {
   DataGroup,
   TimelineOptions,
 } from "vis-timeline";
-import {
-  click,
-  day,
-  rangechanged,
-  scaleChange,
-  scales,
-  select,
-} from "./constants";
+import { click, rangechanged, scaleChange, scales, select } from "./constants";
 import {
   BarchartOptions,
   BarChartItem,
@@ -45,7 +37,6 @@ export const defaultBarchartOptions: BarchartOptions = {
   },
   ...defaultChartOptions,
 };
-const test = 0;
 export class Barchart extends Chart {
   private nodeItemsByScale: Lookup<ItemByScale>;
   private edgeItemsByScale: Lookup<ItemByScale>;
@@ -255,10 +246,20 @@ export class Barchart extends Chart {
   }
 
   protected onRangeChange(force = false) {
-    const { scale, i, name } = this.getScale();
+    const { scale } = this.getScale();
     if (
       (!force && scale === this.currentScale) ||
       !this.nodeItemsByScale[scale]
+    ) {
+      return;
+    }
+    // prevent from too much movement on zoom out
+    if (
+      scale > this.currentScale &&
+      this.currentEdgeData.items.length + this.currentNodeData.items.length < 5 &&
+      this.nodeItemsByScale[scale].items.length +
+        this.nodeItemsByScale[scale].items.length <
+        5
     ) {
       return;
     }

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -171,24 +171,25 @@ export abstract class Chart extends EventEmitter<Events> {
     edgeEnds: number[]
   ): void;
 
-  protected getScale(): number {
+  protected getScale() {
     const { start, end } = this.chart.getWindow();
     const length = +end - +start;
     // choose a scale adapted to zoom
-    const { scale } = scales.reduce(
-      (scale, candidate) => {
+    return scales.reduce(
+      (scale, { millis: candidate, name }, i) => {
         const bars = Math.round(length / candidate);
         if (bars < scale.bars && bars > 10) {
           return {
             bars,
+            name,
             scale: candidate,
+            i,
           };
         }
         return scale;
       },
-      { bars: Infinity, scale: Infinity }
+      { bars: Infinity, scale: Infinity, i: -1, name: "undefined" }
     );
-    return scale;
   }
   destroy() {
     if (this.destroyed) return;

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -178,7 +178,7 @@ export abstract class Chart extends EventEmitter<Events> {
     return scales.reduce(
       (scale, { millis: candidate, name }, i) => {
         const bars = Math.round(length / candidate);
-        if (bars < scale.bars && bars > 10) {
+        if (bars < scale.bars && bars > 2) {
           return {
             bars,
             name,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,10 @@
-import { Scales } from "./types";
+import { Scale } from "./types";
 
 export const day = 1000 * 3600 * 24;
 export const month = day * 30;
 export const year = day * 365;
 
-export const scales: Scales[] = [
+export const scales: Scale[] = [
   {
     name: "millisecond",
     millis: 1,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,48 +1,118 @@
+import { Scales } from "./types";
+
 export const day = 1000 * 3600 * 24;
 export const month = day * 30;
 export const year = day * 365;
 
-export const scales = [
-  // milis
-  1,
-  // second
-  1000,
-  // 5 seconds
-  5000,
-  // 10 seconds
-  10000,
-  // 1 minute
-  60000,
-  // 5 minutes
-  60000 * 5,
-  // 10 minutes
-  60000 * 5,
-  // 1 hour
-  3600 * 1000,
-  // 1 day
-  day,
-  // 1 week
-  7 * day,
-  // 1 month
-  month,
-  // 3 months
-  3 * month,
-  // 6 months
-  0.5 * year,
-  // 1 year
-  year,
-  // 5 years
-  5 * year,
-  // 10 years
-  10 * year,
-  // 10 years
-  50 * year,
-  // 100 years
-  100 * year,
-  // 500 years
-  500 * year,
-  // 1000 years
-  1000 * year,
+export const scales: Scales[] = [
+  {
+    name: "millisecond",
+    millis: 1,
+  },
+  {
+    name: "second",
+    millis: 1000,
+  },
+  {
+    name: "5 seconds",
+    millis: 1000,
+  },
+  {
+    name: "10 seconds",
+    millis: 1000,
+  },
+  {
+    name: "1 minute",
+    millis: 60000,
+  },
+  {
+    name: "5 minutes",
+    millis: 60000 * 5,
+  },
+  {
+    name: "10 minutes",
+    millis: 60000 * 10,
+  },
+  {
+    name: "1 hour",
+    millis: 3600 * 1000,
+    round: (x) =>
+      +new Date(x.getFullYear(), x.getMonth(), x.getDate(), x.getHours(), 30),
+  },
+  {
+    name: "1 day",
+    millis: day,
+    round: (x) => +new Date(x.getFullYear(), x.getMonth(), x.getDate(), 12),
+  },
+  {
+    name: "1 week",
+    millis: 7 * day,
+    round: (x) =>
+      +new Date(
+        x.getFullYear(),
+        x.getMonth(),
+        x.getDate() - x.getDay() + 2,
+        12
+      ),
+  },
+  {
+    name: "1 month",
+    millis: month,
+    round: (x) => +new Date(x.getFullYear(), x.getMonth(), 15, 12),
+  },
+  {
+    name: "3 months",
+    millis: 3 * month,
+    round: (x) =>
+      +new Date(x.getFullYear(), Math.floor(x.getMonth() / 3) * 3 + 1, 15, 12),
+  },
+  {
+    name: "6 months",
+    millis: 6 * month,
+    round: (x) =>
+      +new Date(x.getFullYear(), Math.floor(x.getMonth() / 6) * 6 + 3, 15, 12),
+  },
+  {
+    name: "1 year",
+    millis: year,
+    round: (x) => +new Date(x.getFullYear(), 6, 15, 12),
+  },
+  {
+    name: "5 years",
+    millis: 5 * year,
+    round: (x) =>
+      +new Date((Math.floor(x.getFullYear()) / 5) * 5 + 2, 6, 15, 12),
+  },
+  {
+    name: "10 years",
+    millis: 10 * year,
+    round: (x) =>
+      +new Date((Math.floor(x.getFullYear()) / 10) * 10 + 5, 6, 15, 12),
+  },
+  {
+    name: "50 years",
+    millis: 50 * year,
+    round: (x) =>
+      +new Date((Math.floor(x.getFullYear()) / 50) * 50 + 25, 6, 15, 12),
+  },
+  {
+    name: "100 years",
+    millis: 100 * year,
+    round: (x) =>
+      +new Date((Math.floor(x.getFullYear()) / 100) * 100 + 50, 6, 15, 12),
+  },
+  {
+    name: "500 years",
+    millis: 500 * year,
+    round: (x) =>
+      +new Date((Math.floor(x.getFullYear()) / 500) * 500 + 250, 6, 15, 12),
+  },
+  {
+    name: "1000 years",
+    millis: 1000 * year,
+    round: (x) =>
+      +new Date((Math.floor(x.getFullYear()) / 1000) * 1000 + 500, 6, 15, 12),
+  },
 ];
 
 export const zoomIn = "zoom-in";

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -228,24 +228,24 @@ export class Controller<
 
   showTimeline() {
     const { start, end } = this.barchart.getWindow();
-    this.timeline.chart.setWindow(+start, +end, { animation: false });
     this.timeline.setTimebars(this.barchart.getTimebars());
     this.barchart.container.style.display = "none";
     this.timeline.container.style.display = "";
     this.mode = "timeline";
     this.timeline.visible = true;
     this.barchart.visible = false;
+    this.timeline.chart.setWindow(+start, +end, { animation: false });
   }
 
   showBarchart() {
     const { start, end } = this.timeline.getWindow();
-    this.barchart.chart.setWindow(+start, +end, { animation: false });
     this.barchart.setTimebars(this.timeline.getTimebars());
     this.barchart.container.style.display = "";
     this.timeline.container.style.display = "none";
     this.mode = "barchart";
     this.timeline.visible = false;
     this.barchart.visible = true;
+    this.barchart.chart.setWindow(+start, +end, { animation: false });
   }
 
   addTimeBar(timebar: TimebarOptions): void {

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -131,7 +131,7 @@ export class Timeline extends Chart {
   }
 
   protected onRangeChange() {
-    const scale = this.getScale();
+    const { scale } = this.getScale();
     if (scale === this.currentScale) {
       return;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,8 +166,8 @@ export type Timebar = {
  */
 export type TimebarOptions = { fixed?: boolean; date: Date } | number | Date;
 
-export type Scales = {
+export type Scale = {
   name: string;
   millis: number;
   round?: (date: Date) => number;
-}[];
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,3 +165,9 @@ export type Timebar = {
  * It can be a number, a date or an object.
  */
 export type TimebarOptions = { fixed?: boolean; date: Date } | number | Date;
+
+export type Scales = {
+  name: string;
+  millis: number;
+  round?: (date: Date) => number;
+}[];

--- a/test/timeline.test.ts
+++ b/test/timeline.test.ts
@@ -20,9 +20,9 @@ describe("Timeline", async () => {
       createOgma({
         graph: {
           nodes: [
-            ...new Array(10).fill(0).map((_, i) => ({
+            ...new Array(4).fill(0).map((_, i) => ({
               id: i,
-              data: { start: 0 },
+              data: { start: Math.random() * 3600_000 },
             })),
           ],
           edges: [],
@@ -33,7 +33,7 @@ describe("Timeline", async () => {
         .then(() => afterTimelineRedraw())
         .then(() => document.querySelectorAll(".vis-box.nodes").length);
     });
-    expect(size).toBe(10);
+    expect(size).toBe(4);
   });
 
   test("should respect grouping", async () => {
@@ -43,7 +43,10 @@ describe("Timeline", async () => {
           nodes: [
             ...new Array(10).fill(0).map((_, i) => ({
               id: i,
-              data: { start: 0, type: i % 2 ? "A" : "B" },
+              data: {
+                start: Math.random() * 3600_000,
+                type: i % 2 ? "A" : "B",
+              },
             })),
           ],
           edges: [],
@@ -58,10 +61,10 @@ describe("Timeline", async () => {
         .then(() => afterTimelineRedraw())
         .then(() => [
           document.querySelectorAll(".vis-box.A").length,
-          document.querySelectorAll(".B").length,
+          document.querySelectorAll(".vis-box.B").length,
         ]);
     });
     expect(as).toBe(5);
-    expect(bs).toBe(4);
+    expect(bs).toBe(5);
   });
 });


### PR DESCRIPTION
We were grouping elements by just dividing elements timestamp by the current scale. It was resulting into not very intuitive grouping: on week level for instance an element could end up in the previous week. Now we do the proper clustering for human readable scales. We also center groups better.


Closes #26 